### PR TITLE
Bugfix/parameter input al

### DIFF
--- a/app/pages/account/newexp/page.tsx
+++ b/app/pages/account/newexp/page.tsx
@@ -1,0 +1,21 @@
+import { CSSProperties } from "react";
+import { Box } from "@mui/material";
+import NewExpTab from "@/src/components/Account/NewExpTab";
+
+const containerStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "80vh",
+  padding: "20px",
+  width: "100%",
+};
+
+export default function NewExpPage() {
+  return (
+    <Box sx={containerStyle}>
+      <NewExpTab />
+    </Box>
+  );
+}

--- a/src/components/Account/NewExpTab.tsx
+++ b/src/components/Account/NewExpTab.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 
 // Downloading Files


### PR DESCRIPTION
# Fixing Parameter Input

## Description
Fixed user's not being able to properly put in a number within the parameter range in the textfield. Also created a separate page for the new experiment page for easier redirection in the future. 

## Changes
- Users can now input a number within the range for each parameter. Numbers that go beyond the parameter ranges will automatically default to the min and max of that parameter range. 
- Separate page for the new experiment page (`/pages/accounts/newexp`). This should allow for easier redirection in the future.